### PR TITLE
SolidStamp version #3 - support for IPFS audit reports and more

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sol linguist-language=Solidity

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ truffle test
 ### Deployed Addresses
 
 #### Mainnet
-SolidStampRegister [0xFfE73766Ed803769cDaEA47470E66fdfa5308c22](https://etherscan.io/address/0xFfE73766Ed803769cDaEA47470E66fdfa5308c22)
+SolidStampRegister [0x39b46de96cFe29fFCf225e899B8ffe1f7fBbA59e](https://etherscan.io/address/0x39b46de96cFe29fFCf225e899B8ffe1f7fBbA59e)
 
-SolidStamp [0x16964D770439B1d2Ae84EC96a18eDb1657CFfEcF](https://etherscan.io/address/0x16964D770439B1d2Ae84EC96a18eDb1657CFfEcF)
+SolidStamp [0x165cFb9cCf8b185E03205Ab4118eA6afBdbA9203](https://etherscan.io/address/0x165cFb9cCf8b185E03205Ab4118eA6afBdbA9203)
 
 
 #### Ropsten

--- a/README.md
+++ b/README.md
@@ -29,12 +29,14 @@ truffle test
 
 #### Mainnet
 SolidStampRegister [0xFfE73766Ed803769cDaEA47470E66fdfa5308c22](https://etherscan.io/address/0xFfE73766Ed803769cDaEA47470E66fdfa5308c22)
+
 SolidStamp [0x16964D770439B1d2Ae84EC96a18eDb1657CFfEcF](https://etherscan.io/address/0x16964D770439B1d2Ae84EC96a18eDb1657CFfEcF)
 
 
 #### Ropsten
-SolidStampRegister [0x165cFb9cCf8b185E03205Ab4118eA6afBdbA9203](https://etherscan.io/address/0x165cFb9cCf8b185E03205Ab4118eA6afBdbA9203)
-SolidStamp [0x034464DB73874a8650535f931D831439CAAEe29d](https://etherscan.io/address/0x034464DB73874a8650535f931D831439CAAEe29d)
+SolidStampRegister [0x4ad5766168f631aea2b6e5bbcfa1553e05f25c47](https://etherscan.io/address/0x4ad5766168f631aea2b6e5bbcfa1553e05f25c47)
+
+SolidStamp [0x81d5c4488f3a5ffd8b3a7445f7d6ee943c38eba7](https://etherscan.io/address/0x81d5c4488f3a5ffd8b3a7445f7d6ee943c38eba7)
 
 ## Built With
 * [Truffle](https://github.com/trufflesuite/truffle) - Ethereum development environment

--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ SolidStamp [0x16964D770439B1d2Ae84EC96a18eDb1657CFfEcF](https://etherscan.io/add
 
 
 #### Ropsten
-SolidStampRegister [0x4ad5766168f631aea2b6e5bbcfa1553e05f25c47](https://etherscan.io/address/0x4ad5766168f631aea2b6e5bbcfa1553e05f25c47)
+SolidStampRegister [0x77dbc13b80f2bbc31b92a40abb8c22e0e9b879d4](https://etherscan.io/address/0x77dbc13b80f2bbc31b92a40abb8c22e0e9b879d4)
 
-SolidStamp [0x81d5c4488f3a5ffd8b3a7445f7d6ee943c38eba7](https://etherscan.io/address/0x81d5c4488f3a5ffd8b3a7445f7d6ee943c38eba7)
+SolidStamp [0x8E12DFa382aE33563c77A1a62536D4F6Bf6D0d2F](https://etherscan.io/address/0x8E12DFa382aE33563c77A1a62536D4F6Bf6D0d2F)
 
 ## Built With
 * [Truffle](https://github.com/trufflesuite/truffle) - Ethereum development environment

--- a/contracts/SolidStamp.sol
+++ b/contracts/SolidStamp.sol
@@ -154,6 +154,19 @@ contract SolidStamp is Ownable, Pausable, Upgradable {
         msg.sender.transfer(reward.sub(commissionKept));
     }
 
+    /// @notice marks multiple contracts as audited
+    /// @param _codeHashes the code hashes of the stamped contracts. each _codeHash equals to sha3 of the contract byte-code
+    /// @param _reportIPFS IPFS hash of the audit report
+    /// @param _isApproved whether the contracts are approved or rejected
+    function auditContracts(bytes32[] _codeHashes, bytes _reportIPFS, bool _isApproved)
+    public whenNotPaused
+    {
+        for(uint i=0; i<_codeHashes.length; i++ )
+        {
+            auditContract(_codeHashes[i], _reportIPFS, _isApproved);
+        }
+    }
+
     /// @dev const value to indicate the maximum commision service owner can set
     uint public constant MAX_COMMISSION = 33;
 

--- a/contracts/SolidStamp.sol
+++ b/contracts/SolidStamp.sol
@@ -195,7 +195,7 @@ contract SolidStamp is Ownable, Pausable, Upgradable {
         super.unpause();
     }
 
-    /// @notice We don't welcome tips & donations
+    /// @notice We don't want your arbitrary ether
     function() payable public {
         revert();
     }

--- a/contracts/SolidStamp.sol
+++ b/contracts/SolidStamp.sol
@@ -25,8 +25,8 @@ contract SolidStamp is Ownable, Pausable, Upgradable {
     // @dev amount of collected commision available to withdraw
     uint public AvailableCommission = 0;
 
-    // @dev commission percentage, initially 9%
-    uint public Commission = 9;
+    // @dev commission percentage, initially 1%
+    uint public Commission = 1;
 
     /// @dev event fired when the service commission is changed
     event NewCommission(uint commmission);
@@ -158,7 +158,7 @@ contract SolidStamp is Ownable, Pausable, Upgradable {
     }
 
     /// @dev const value to indicate the maximum commision service owner can set
-    uint public constant MAX_COMMISSION = 33;
+    uint public constant MAX_COMMISSION = 9;
 
     /// @notice ability for owner to change the service commmission
     /// @param _newCommission new commision percentage

--- a/contracts/SolidStampRegister.sol
+++ b/contracts/SolidStampRegister.sol
@@ -99,4 +99,9 @@ contract SolidStampRegister is Ownable
       emit SolidStampContractChanged(_newSolidStamp);
       ContractSolidStamp = _newSolidStamp;
     }
+
+    /// @notice We don't want your arbitrary ether
+    function() payable public {
+        revert();
+    }    
 }

--- a/contracts/SolidStampRegister.sol
+++ b/contracts/SolidStampRegister.sol
@@ -81,7 +81,7 @@ contract SolidStampRegister is Ownable
     /// @param _codeHashes the code hashes of the stamped contracts. each _codeHash equals to sha3 of the contract byte-code
     /// @param _reportIPFS IPFS hash of the audit report
     /// @param _isApproved whether the contracts are approved or rejected
-    function auditContracts(bytes32[] _codeHashes, bytes _reportIPFS, bool _isApproved) public
+    function registerAudits(bytes32[] _codeHashes, bytes _reportIPFS, bool _isApproved) public
     {
         for(uint i=0; i<_codeHashes.length; i++ )
         {

--- a/contracts/SolidStampRegister.sol
+++ b/contracts/SolidStampRegister.sol
@@ -27,23 +27,7 @@ contract SolidStampRegister is Ownable
     event AuditRegistered(address auditor, bytes32 codeHash, bool isApproved);
 
     /// @notice SolidStampRegister constructor
-    /// @dev import audits from the SolidStamp v1 contract deployed to: 0x0aA7A4482780F67c6B2862Bd68CD67A83faCe355
-    /// @param _existingAuditors list of existing auditors
-    /// @param _existingCodeHashes list of existing code hashes
-    /// @param _outcomes list of existing audit outcomes
-    /// @dev each n-th element represents an existing audit conducted by _existingAuditors[n]
-    /// on code hash _existingCodeHashes[n] with an outcome _outcomes[n]
-    constructor(address[] _existingAuditors, bytes32[] _existingCodeHashes, bool[] _outcomes) public {
-        uint noOfExistingAudits = _existingAuditors.length;
-        require(noOfExistingAudits == _existingCodeHashes.length, "paramters mismatch");
-        require(noOfExistingAudits == _outcomes.length, "paramters mismatch");
-
-        // set contract address temporarily to owner so that registerAuditOutcome does not revert
-        contractSolidStamp = msg.sender;
-        for (uint i=0; i<noOfExistingAudits; i++){
-            registerAuditOutcome(_existingAuditors[i], _existingCodeHashes[i], _outcomes[i]);
-        }
-        contractSolidStamp = 0x0;
+    constructor() public {
     }
 
     function getAuditOutcome(address _auditor, bytes32 _codeHash) public view returns (uint8)

--- a/contracts/SolidStampRegister.sol
+++ b/contracts/SolidStampRegister.sol
@@ -1,7 +1,7 @@
 pragma solidity ^0.4.24;
 
 import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
-
+import "./SolidStamp.sol";
 
 contract SolidStampRegister is Ownable
 {
@@ -38,6 +38,8 @@ contract SolidStampRegister is Ownable
     }
 
     /// @notice returns the outcome of the audit or NOT_AUDITED (0) if none
+    /// @param _auditor audtior address
+    /// @param _codeHash contract code-hash
     function getAuditOutcome(address _auditor, bytes32 _codeHash) public view returns (uint8)
     {
         bytes32 hashAuditorCode = keccak256(abi.encodePacked(_auditor, _codeHash));
@@ -45,18 +47,23 @@ contract SolidStampRegister is Ownable
     }
 
     /// @notice returns the audit report IPFS of the audit or 0x0 if none
+    /// @param _auditor audtior address
+    /// @param _codeHash contract code-hash
     function getAuditReportIPFS(address _auditor, bytes32 _codeHash) public view returns (bytes)
     {
         bytes32 hashAuditorCode = keccak256(abi.encodePacked(_auditor, _codeHash));
         return Audits[hashAuditorCode].reportIPFS;
     }
 
-    function registerAudit(address _auditor, bytes32 _codeHash, bytes _reportIPFS, bool _isApproved) public onlySolidStampContract
+    /// @notice marks contract as audited
+    /// @param _codeHash the code hash of the stamped contract. _codeHash equals to sha3 of the contract byte-code
+    /// @param _reportIPFS IPFS hash of the audit report
+    /// @param _isApproved whether the contract is approved or rejected
+    function registerAudit(bytes32 _codeHash, bytes _reportIPFS, bool _isApproved) public
     {
-        require(_auditor != 0x0, "auditor cannot be 0x0");
         require(_codeHash != 0x0, "codeHash cannot be 0x0");
         require(_reportIPFS.length != 0x0, "report IPFS cannot be 0x0");
-        bytes32 hashAuditorCode = keccak256(abi.encodePacked(_auditor, _codeHash));
+        bytes32 hashAuditorCode = keccak256(abi.encodePacked(msg.sender, _codeHash));
 
         Audit storage audit = Audits[hashAuditorCode];
         require(audit.outcome == NOT_AUDITED, "already audited");
@@ -66,27 +73,30 @@ contract SolidStampRegister is Ownable
         else
             audit.outcome = AUDITED_AND_REJECTED;
         audit.reportIPFS = _reportIPFS;
-        emit AuditRegistered(_auditor, _codeHash, _reportIPFS, _isApproved);
+        SolidStamp(ContractSolidStamp).auditContract(msg.sender, _codeHash, _reportIPFS, _isApproved);
+        emit AuditRegistered(msg.sender, _codeHash, _reportIPFS, _isApproved);
     }
+
+    /// @notice marks multiple contracts as audited
+    /// @param _codeHashes the code hashes of the stamped contracts. each _codeHash equals to sha3 of the contract byte-code
+    /// @param _reportIPFS IPFS hash of the audit report
+    /// @param _isApproved whether the contracts are approved or rejected
+    function auditContracts(bytes32[] _codeHashes, bytes _reportIPFS, bool _isApproved) public
+    {
+        for(uint i=0; i<_codeHashes.length; i++ )
+        {
+            registerAudit(_codeHashes[i], _reportIPFS, _isApproved);
+        }
+    }
+
 
     event SolidStampContractChanged(address newSolidStamp);
 
-    /**
-     * @dev Throws if called by any account other than the contractSolidStamp
-     */
-    modifier onlySolidStampContract() {
-      require(msg.sender == ContractSolidStamp, "cannot be run by not SolidStamp contract");
-      _;
-    }
-
-    /**
-     * @dev Transfers control of the registry to a _newSolidStamp.
-     * @param _newSolidStamp The address to transfer control registry to.
-     */
+    /// @dev Transfers SolidStamp contract a _newSolidStamp.
+    /// @param _newSolidStamp The address to transfer SolidStamp address to.
     function changeSolidStampContract(address _newSolidStamp) public onlyOwner {
       require(_newSolidStamp != address(0), "SolidStamp contract cannot be 0x0");
       emit SolidStampContractChanged(_newSolidStamp);
       ContractSolidStamp = _newSolidStamp;
     }
-
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -299,9 +299,9 @@
       "integrity": "sha512-Ds/TEoZjwggRoz/Q2O7SE3i4Jm66mqTDfmdHdq/7DKVk3bro9Q8h6WdXKdPqFLMoqxrDK5SVRzHVPOS6uuGtrg=="
     },
     "error-ex": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
-      "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "requires": {
         "is-arrayish": "^0.2.1"
       }
@@ -996,9 +996,9 @@
       }
     },
     "hosted-git-info": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.0.tgz",
-      "integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw=="
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
+      "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w=="
     },
     "inflight": {
       "version": "1.0.6",
@@ -1039,7 +1039,7 @@
     },
     "is-builtin-module": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "requires": {
         "builtin-modules": "^1.0.0"
@@ -1142,7 +1142,7 @@
     },
     "jsonfile": {
       "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+      "resolved": "http://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
       "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
       "requires": {
         "graceful-fs": "^4.1.6"
@@ -1183,7 +1183,7 @@
     },
     "load-json-file": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "requires": {
         "graceful-fs": "^4.1.2",
@@ -1401,7 +1401,7 @@
     },
     "os-locale": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
       "requires": {
         "lcid": "^1.0.0"
@@ -1675,9 +1675,9 @@
       }
     },
     "semver": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
+      "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw=="
     },
     "set-blocking": {
       "version": "2.0.0",
@@ -1735,9 +1735,9 @@
       "integrity": "sha1-tZ8HPGn+MyVg1aEMMrqMp/KYbPs="
     },
     "solc": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/solc/-/solc-0.4.24.tgz",
-      "integrity": "sha512-2xd7Cf1HeVwrIb6Bu1cwY2/TaLRodrppCq3l7rhLimFQgmxptXhTC3+/wesVLpB09F1A2kZgvbMOgH7wvhFnBQ==",
+      "version": "0.4.25",
+      "resolved": "https://registry.npmjs.org/solc/-/solc-0.4.25.tgz",
+      "integrity": "sha512-jU1YygRVy6zatgXrLY2rRm7HW1d7a8CkkEgNJwvH2VLpWhMFsMdWcJn6kUqZwcSz/Vm+w89dy7Z/aB5p6AFTrg==",
       "requires": {
         "fs-extra": "^0.30.0",
         "memorystream": "^0.3.1",
@@ -1875,9 +1875,9 @@
       }
     },
     "spdx-correct": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
-      "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.1.tgz",
+      "integrity": "sha512-hxSPZbRZvSDuOvADntOElzJpenIR7wXJkuoUcUtS0erbgt2fgeaoPIYretfKpslMhfFDY4k0MZ2F5CUzhBsSvQ==",
       "requires": {
         "spdx-expression-parse": "^3.0.0",
         "spdx-license-ids": "^3.0.0"
@@ -1898,9 +1898,9 @@
       }
     },
     "spdx-license-ids": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
-      "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.1.tgz",
+      "integrity": "sha512-TfOfPcYGBB5sDuPn3deByxPhmfegAhpDYKSOXZQN81Oyrrif8ZCodOLzK3AesELnCx03kikhyDwh0pfvvQvF8w=="
     },
     "string-width": {
       "version": "1.0.2",
@@ -1960,9 +1960,9 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "validate-npm-package-license": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
-      "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
       "requires": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
@@ -2012,7 +2012,7 @@
     },
     "yargs": {
       "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
+      "resolved": "http://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
       "integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
       "requires": {
         "cliui": "^3.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -197,14 +197,14 @@
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
     "colors": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.2.5.tgz",
-      "integrity": "sha512-erNRLao/Y3Fv54qUa0LBB+//Uf3YwMUmdJinN20yMXm9zdKKqH9wt7R9IIVZ+K7ShzfpLV/Zg8+VyrBJYB4lpg=="
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.1.tgz",
+      "integrity": "sha512-jg/vxRmv430jixZrC+La5kMbUWqIg32/JsYNZb94+JEmzceYbWKTsv1OuTp+7EaqiaWRR2tPcykibwCRgclIsw=="
     },
     "commander": {
-      "version": "2.15.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
+      "version": "2.17.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
+      "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg=="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -292,6 +292,11 @@
         "minimalistic-assert": "^1.0.0",
         "minimalistic-crypto-utils": "^1.0.0"
       }
+    },
+    "eol": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/eol/-/eol-0.9.1.tgz",
+      "integrity": "sha512-Ds/TEoZjwggRoz/Q2O7SE3i4Jm66mqTDfmdHdq/7DKVk3bro9Q8h6WdXKdPqFLMoqxrDK5SVRzHVPOS6uuGtrg=="
     },
     "error-ex": {
       "version": "1.3.1",
@@ -1390,9 +1395,9 @@
       }
     },
     "openzeppelin-solidity": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-1.10.0.tgz",
-      "integrity": "sha512-igkrumQQ2lrN2zjeQV4Dnb0GpTBj1fzMcd8HPyBUqwI0hhuscX/HzXiqKT6gFQl1j9Wy/ppVVs9fqL/foF7Gmg=="
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-1.12.0.tgz",
+      "integrity": "sha512-WlorzMXIIurugiSdw121RVD5qA3EfSI7GybTn+/Du0mPNgairjt29NpVTAaH8eLjAeAwlw46y7uQKy0NYem/gA=="
     },
     "os-locale": {
       "version": "1.4.0",
@@ -1408,9 +1413,9 @@
       "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
     },
     "p-limit": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
-      "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
       "requires": {
         "p-try": "^1.0.0"
       }
@@ -1514,9 +1519,9 @@
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
     },
     "randomatic": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.0.0.tgz",
-      "integrity": "sha512-VdxFOIEY3mNO5PtSRkkle/hPJDHvQhK21oa73K4yAc9qmp6N429gAyF1gZMOTMeS0/AYzaV/2Trcef+NaIonSA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.0.tgz",
+      "integrity": "sha512-KnGPVE0lo2WoXxIZ7cPR8YBpiol4gsSuOwDSg410oHh80ZMp5EiypNqL2K4Z77vJn6lB5rap7IkAmcUlalcnBQ==",
       "requires": {
         "is-number": "^4.0.0",
         "kind-of": "^6.0.0",
@@ -1742,14 +1747,15 @@
       }
     },
     "solium": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/solium/-/solium-1.1.7.tgz",
-      "integrity": "sha512-yYbalsrzJCU+QJ0HZvxAT4IQIqI1e6KPW2vop0NaHwdijqhQC9fJkVioCrL18NbO2Z8rdcnx8Y0JpvYJWrIjRg==",
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/solium/-/solium-1.1.8.tgz",
+      "integrity": "sha512-fn0lusM6of14CytIDDHK73SGjn6NsVTaCVJjaKCKJyqKhT00rH/hDtvnIeZ2ZTD9z/xaXd4Js2brW3az6AV9RA==",
       "requires": {
         "ajv": "^5.2.2",
         "chokidar": "^1.6.0",
         "colors": "^1.1.2",
         "commander": "^2.9.0",
+        "eol": "^0.9.1",
         "js-string-escape": "^1.0.1",
         "lodash": "^4.14.2",
         "sol-digger": "0.0.2",
@@ -1963,9 +1969,9 @@
       }
     },
     "which": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
-      "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "requires": {
         "isexe": "^2.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "devDependencies": {},
     "dependencies": {
         "ethereumjs-abi": "^0.6.5",
-        "openzeppelin-solidity": "1.10.0",
+        "openzeppelin-solidity": "1.12.0",
         "solc": "^0.4.24",
-        "solium": "^1.1.7"
+        "solium": "^1.1.8"
     }
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "dependencies": {
         "ethereumjs-abi": "^0.6.5",
         "openzeppelin-solidity": "1.12.0",
-        "solc": "^0.4.24",
+        "solc": "^0.4.25",
         "solium": "^1.1.8"
     }
 }

--- a/scripts/solidityFlattener.pl
+++ b/scripts/solidityFlattener.pl
@@ -1,0 +1,138 @@
+#!/usr/bin/perl -W
+# ----------------------------------------------------------------------------------------------
+# Solidity Flattener v1.0.2
+#
+# https://github.com/bokkypoobah/SolidityFlattener
+#
+# Enjoy. (c) BokkyPooBah / Bok Consulting Pty Ltd 2018. The MIT Licence.
+# ----------------------------------------------------------------------------------------------
+
+use strict;
+use Getopt::Long qw(:config no_auto_abbrev);
+use File::Basename;
+use File::Spec::Functions;
+
+my $DEFAULTCONTRACTSDIR = "./contracts";
+my $VERSION = "v1.0.2";
+
+my $helptext = qq\
+Solidity Flattener $VERSION
+
+Usage: $0 {options}
+
+Where options are:
+  --contractsdir  Source directory for original contracts. Default '$DEFAULTCONTRACTSDIR'
+  --remapdir      Remap import directories. Optional. Example "contracts/openzeppelin-solidity=node_modules/openzeppelin-solidity"
+  --mainsol       Main source Solidity file. Mandatory
+  --outputsol     Output flattened Solidity file. Default is mainsol with `_flattened` appended to the file name
+  --verbose       Show details. Optional
+  --help          Display help. Optional
+
+Example usage:
+  $0 --contractsdir=contracts --mainsol=MyContract.sol --outputsol=flattened/MyContracts_flattened.sol --verbose
+
+Installation:
+  Download solidityFlattener.pl from https://github.com/bokkypoobah/SolidityFlattener into /usr/local/bin
+  chmod 755 /usr/local/bin/solidityFlattener.pl
+
+Works on OS/X, Linux and Linux on Windows.
+
+Enjoy. (c) BokkyPooBah / Bok Consulting Pty Ltd 2018. The MIT Licence.
+
+Stopped\;
+
+my ($contractsdir, $remapdir, $mainsol, $outputsol, $help, $verbose);
+my %seen = ();
+
+GetOptions(
+  "contractsdir:s" => \$contractsdir,
+  "remapdir:s"     => \$remapdir,
+  "mainsol:s"      => \$mainsol,
+  "outputsol:s"    => \$outputsol,
+  "verbose"        => \$verbose,
+  "help"           => \$help)
+or die $helptext;
+
+die $helptext
+  if defined $help;
+
+die $helptext
+  unless defined $mainsol;
+
+$contractsdir = $DEFAULTCONTRACTSDIR
+  unless defined $contractsdir;
+
+if (!defined $outputsol) {
+  $outputsol = $mainsol;
+  $outputsol =~ s/\.sol/_flattened\.sol/g;
+}
+
+if (defined $verbose) {
+  printf "contractsdir: %s\n", $contractsdir;
+  printf "remapdir    : %s\n", defined $remapdir ? $remapdir : "(no remapping)";
+  printf "mainsol     : %s\n", $mainsol;
+  printf "outputsol   : %s\n", $outputsol
+}
+
+open OUTPUT, ">$outputsol"
+  or die "Cannot open $outputsol for writing. Stopped";
+
+processSol(catfile($contractsdir, $mainsol), 0);
+
+close OUTPUT
+  or die "Cannot close $outputsol. Stopped";
+
+exit;
+
+
+# ------------------------------------------------------------------------------
+# Process Solidity file
+# ------------------------------------------------------------------------------
+sub processSol {
+  my ($sol, $level) = @_;
+  if (defined $remapdir) {
+    my ($splitfrom, $splitto) = split /=/, $remapdir;
+    # printf "%sSplit %s: %s => %s\n", "    " x $level, $remapdir, $splitfrom, $splitto
+    #   if defined $verbose;
+    if ($sol =~ /$splitfrom/) {
+      printf "%sRemapping %s\n", "    " x $level, $sol
+        if defined $verbose;
+      $sol =~ s!$splitfrom!$splitto!;
+      printf "%s       to %s\n", "    " x $level, $sol
+        if defined $verbose;
+    }
+  }
+  my $dir = dirname($sol);
+  my $file = basename($sol);
+  $seen{$file} = 1;
+  printf "%sProcessing %s\n", "    " x $level, $sol
+    if defined $verbose;
+
+  open INPUT, "<$sol"
+    or die "Cannot open $sol for reading. Stopped";
+  my @lines = <INPUT>;
+  close INPUT
+    or die "Cannot close $sol. Stopped";
+
+  for my $line (@lines) {
+    chomp $line;
+    if ($line =~ /^import/) {
+      my $importfile = $line;
+      $importfile =~ s/import \"//;
+      $importfile =~ s/\";.*$//;
+      $file = basename($importfile);
+      if ($seen{$file}) {
+        printf "%s    Already Imported %s\n", "    " x $level, catfile($dir, $importfile)
+          if defined $verbose;
+      } else {
+        printf "%s    Importing %s\n", "    " x $level, catfile($dir, $importfile)
+          if defined $verbose;
+        processSol(catfile($dir, $importfile), $level + 1)
+      }
+    } else {
+      if ($level == 0 || !($line =~ /^pragma/)) {
+        printf OUTPUT "%s\n", $line;
+      }
+    }
+  }
+}

--- a/test/SolidStamp.test.js
+++ b/test/SolidStamp.test.js
@@ -181,7 +181,7 @@ contract('SolidStamp', function(accounts) {
         });
     });
 
-    it("contract should not accept ordinary money transfers (tips & donations)", async function(){
+    it("contract should not accept arbitrary ether", async function(){
         await assertRevert(ss.sendTransaction({from:sender2, value:10}));
     });
 

--- a/test/SolidStamp.test.js
+++ b/test/SolidStamp.test.js
@@ -14,7 +14,7 @@ contract('SolidStamp', function(accounts) {
     let ss, ssr;
 
     beforeEach(async function () {
-        ssr = await SolidStampRegister.new([],[],[], {from: owner});
+        ssr = await SolidStampRegister.new({from: owner});
         ss = await SolidStamp.new(ssr.address, {from: owner});
         await ssr.changeSolidStampContract(ss.address);
         hash2 = '0x' + abi.soliditySHA3(

--- a/test/SolidStampRegister.test.js
+++ b/test/SolidStampRegister.test.js
@@ -11,24 +11,13 @@ contract('SolidStampRegister', function(accounts) {
     let ssr, NOT_AUDITED, AUDITED_AND_APPROVED, AUDITED_AND_REJECTED;
 
     beforeEach(async function () {
-        ssr = await SolidStampRegister.new([auditor, auditor2],[codeHash, codeHash2],[true, false], {from: owner});
+        ssr = await SolidStampRegister.new({from: owner});
         NOT_AUDITED = await ssr.NOT_AUDITED();
         AUDITED_AND_APPROVED = await ssr.AUDITED_AND_APPROVED();
         AUDITED_AND_REJECTED = await ssr.AUDITED_AND_REJECTED();
         await ssr.changeSolidStampContract(contract);
     });
 
-    describe("#constructor", function () {
-        it("should revert on length of arguments mismatch", async function() {
-            await assertRevert(SolidStampRegister.new([],[],[true], {from: owner}));
-            await assertRevert(SolidStampRegister.new([],[0x0],[], {from: owner}));
-            await assertRevert(SolidStampRegister.new([0x0],[],[true], {from: owner}));
-        });
-        it("should register audits upon contract constuction", async function() {
-            eq((await ssr.getAuditOutcome(auditor, codeHash, {from: sender})).valueOf(), AUDITED_AND_APPROVED.valueOf(), '1st audit not registered');
-            eq((await ssr.getAuditOutcome(auditor2, codeHash2, {from: sender})).valueOf(), AUDITED_AND_REJECTED.valueOf(), '2nd audit not registered');
-        });
-    });
     describe("#getAuditOutcome", function() {
         it("should return registered audit", async function() {
             await ssr.registerAuditOutcome(auditor, codeHash2, false, {from: contract});

--- a/test/SolidStampRegister.test.js
+++ b/test/SolidStampRegister.test.js
@@ -79,7 +79,7 @@ contract('SolidStampRegister', function(accounts) {
             eq((await ssr.getAuditOutcome(auditor, codeHash2, {from: sender})).valueOf(), AUDITED_AND_APPROVED.valueOf(), 'Incorrect return for audited contract');
         });
 
-    })    
+    })
     describe("#changeSolidStampContract", function() {
         it("should fail if not called by owner", async function() {
             await assertRevert(ssr.changeSolidStampContract(sender2, {from: sender}))
@@ -95,4 +95,8 @@ contract('SolidStampRegister', function(accounts) {
             eq(result.logs[0].args['newSolidStamp'], sender2, 'Wrong event data (newSolidStamp)');
         });
     });
+
+    it("contract should not accept arbitrary ether", async function(){
+        await assertRevert(ss.sendTransaction({from:sender2, value:10}));
+    });    
 });

--- a/test/SolidStampRegister.test.js
+++ b/test/SolidStampRegister.test.js
@@ -69,6 +69,17 @@ contract('SolidStampRegister', function(accounts) {
             await assertRevert(ssr.registerAudit(codeHash2, reportIPFS, false, {from: auditor}));
         })
     });
+    describe("#registerAudits", function () {
+        it("should register multiple audits", async function() {
+            const AUDITED_AND_APPROVED = await ssr.AUDITED_AND_APPROVED();
+            let result = await ssr.registerAudits([codeHash, codeHash2], reportIPFS, true, {from: auditor});
+            eq((await ssr.getAuditReportIPFS(auditor, codeHash, {from: sender})).valueOf(), web3.toHex(reportIPFS), 'Audit not registered');
+            eq((await ssr.getAuditReportIPFS(auditor, codeHash2, {from: sender})).valueOf(), web3.toHex(reportIPFS), 'Audit not registered');
+            eq((await ssr.getAuditOutcome(auditor, codeHash, {from: sender})).valueOf(), AUDITED_AND_APPROVED.valueOf(), 'Incorrect return for audited contract');
+            eq((await ssr.getAuditOutcome(auditor, codeHash2, {from: sender})).valueOf(), AUDITED_AND_APPROVED.valueOf(), 'Incorrect return for audited contract');
+        });
+
+    })    
     describe("#changeSolidStampContract", function() {
         it("should fail if not called by owner", async function() {
             await assertRevert(ssr.changeSolidStampContract(sender2, {from: sender}))

--- a/test/helpers/randomArrayOfBytes.js
+++ b/test/helpers/randomArrayOfBytes.js
@@ -1,0 +1,3 @@
+module.exports = function randomArrayOfBytes(len) {
+    return Array.from({length: len}, () => Math.floor(Math.random() * 256));
+}

--- a/upgrades/v2_to_v3/readme.md
+++ b/upgrades/v2_to_v3/readme.md
@@ -1,10 +1,10 @@
 1. Pause the SolidStamp v2 contract via MEW (Use contract ABI and call pause())
-2. Compile and Deploy SolidStampRegister. Use constructor data from 3.
+2. Compile and Deploy SolidStampRegister.
 3. Verify contract source code.
-4. Generate constructor data for SolidStamp
+4. Generate constructor data for SolidStamp contract (https://abi.sonnguyen.ws/)
 5. Deploy SolidStamp.
 6. Verify contract source code.
-7. Call changeSolidStampContract() to change the contractSolidStamp
+7. Call SolidStampRegister.changeSolidStampContract() to change the contractSolidStamp
 8. Change contract address and abi on server. Deploy
 9. Call setNewAddress on the old contract
 10. Tag the new contract as Version 3.0 and update addresses on GitHub

--- a/upgrades/v2_to_v3/readme.md
+++ b/upgrades/v2_to_v3/readme.md
@@ -1,4 +1,4 @@
-1. Pause the SolidStamp v2 contract via MEW (Use contract ABI and call pause())
+1. Pause the SolidStamp v2 contract via MyCrypto (Use contract ABI and call pause())
 2. Compile and Deploy SolidStampRegister.
 3. Verify contract source code.
 4. Generate constructor data for SolidStamp contract (https://abi.sonnguyen.ws/)

--- a/upgrades/v2_to_v3/readme.md
+++ b/upgrades/v2_to_v3/readme.md
@@ -1,0 +1,10 @@
+1. Pause the SolidStamp v2 contract via MEW (Use contract ABI and call pause())
+2. Compile and Deploy SolidStampRegister. Use constructor data from 3.
+3. Verify contract source code.
+4. Generate constructor data for SolidStamp
+5. Deploy SolidStamp.
+6. Verify contract source code.
+7. Call changeSolidStampContract() to change the contractSolidStamp
+8. Change contract address and abi on server. Deploy
+9. Call setNewAddress on the old contract
+10. Tag the new contract as Version 3.0 and update addresses on GitHub

--- a/upgrades/v2_to_v3/readme.md
+++ b/upgrades/v2_to_v3/readme.md
@@ -3,7 +3,7 @@
 3. Verify contract source code.
 4. Generate constructor data for SolidStamp contract (https://abi.sonnguyen.ws/)
 5. Deploy SolidStamp.
-6. Verify contract source code.
+6. Verify contract source code (flatten the source code: `./scripts/solidityFlattener.pl --mainsol SolidStamp.sol --verbose --remapdir openzeppelin-solidity/=../node_modules/openzeppelin-solidity/`)
 7. Call SolidStampRegister.changeSolidStampContract() to change the contractSolidStamp
 8. Change contract address and abi on server. Deploy
 9. Call setNewAddress on the old contract


### PR DESCRIPTION
Changes:
- store audit report IPFS hash along with the stamp
- allow to stamp multiple contracts with one method
- changed intitial commission to 1% and max to 9%
- updated OpenZeppelin to 1.12.0
- updated tests
